### PR TITLE
Add support to api base url

### DIFF
--- a/cmd/branches.go
+++ b/cmd/branches.go
@@ -25,7 +25,7 @@ var listBranchesCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List branches",
 	Run: func(cmd *cobra.Command, args []string) {
-		result, err := gpf.ListBranches(Token)
+		result, err := gpf.ListBranches(BaseURL, Token)
 		if err != nil {
 			fmt.Printf("%s\n", err)
 			os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	Token string
+	Token   string
+	BaseURL string
 )
 
 var RootCmd = &cobra.Command{
@@ -20,5 +21,6 @@ var RootCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.PersistentFlags().StringVarP(&Token, "token", "", "", "Private token")
+	RootCmd.PersistentFlags().StringVarP(&Token, "token", "t", "", "Private token")
+	RootCmd.PersistentFlags().StringVarP(&BaseURL, "baseURL", "b", "https://gitlab.com/api/v3", "Base URL")
 }

--- a/gpf/branches.go
+++ b/gpf/branches.go
@@ -6,8 +6,9 @@ import (
 	"github.com/xanzy/go-gitlab"
 )
 
-func ListBranches(token string) ([]*gitlab.Branch, error) {
+func ListBranches(baseURL string, token string) ([]*gitlab.Branch, error) {
 	git := gitlab.NewClient(nil, token)
+	git.SetBaseURL(baseURL)
 
 	pid := 1
 	branches, _, err := git.Branches.ListBranches(pid)


### PR DESCRIPTION
This PR adds support to set the base url.

As GitLab is an open source tool that allows on-site installs there are many cases where `gpf` is going to be used in a private environment (community edition).
